### PR TITLE
Support SDL_Wait to reduce continuous polling for events

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -291,30 +291,39 @@ int main(int argc, char* argv[])
 
 	int lastTime = SDL_GetTicks();
 	bool running = true;
-
+	
+	// Smog, named after the Flux of The Shadows from Galactic Football, 
+	// switches loop between Polling and Waiting.
+	Uint8 smog = 0;
+	
 	while(running)
 	{
 		SDL_Event event;
-		while(SDL_PollEvent(&event))
+		if(++smog < 100 ? SDL_PollEvent(&event) : SDL_WaitEvent(&event))
 		{
-			switch(event.type)
+			smog = 0;
+			do
 			{
-				case SDL_JOYHATMOTION:
-				case SDL_JOYBUTTONDOWN:
-				case SDL_JOYBUTTONUP:
-				case SDL_KEYDOWN:
-				case SDL_KEYUP:
-				case SDL_JOYAXISMOTION:
-				case SDL_TEXTINPUT:
-				case SDL_TEXTEDITING:
-				case SDL_JOYDEVICEADDED:
-				case SDL_JOYDEVICEREMOVED:
-					InputManager::getInstance()->parseEvent(event, &window);
-					break;
-				case SDL_QUIT:
-					running = false;
-					break;
-			}
+				switch(event.type)
+				{
+					case SDL_JOYHATMOTION:
+					case SDL_JOYBUTTONDOWN:
+					case SDL_JOYBUTTONUP:
+					case SDL_KEYDOWN:
+					case SDL_KEYUP:
+					case SDL_JOYAXISMOTION:
+					case SDL_TEXTINPUT:
+					case SDL_TEXTEDITING:
+					case SDL_JOYDEVICEADDED:
+					case SDL_JOYDEVICEREMOVED:
+						InputManager::getInstance()->parseEvent(event, &window);
+						break;
+					case SDL_QUIT:
+						running = false;
+						break;
+				}
+			} while (SDL_PollEvent(&event));
+			lastTime = SDL_GetTicks();
 		}
 
 		if(window.isSleeping())


### PR DESCRIPTION
Added support to switch to SDL_Wait which waits for events rather than polling continuously. CPU is around 1-5% while Emulation station is idle (not in sleep mode).